### PR TITLE
updated the existing non association test

### DIFF
--- a/src/pages/BookingConfirmationPage.ts
+++ b/src/pages/BookingConfirmationPage.ts
@@ -6,6 +6,7 @@ export default class BookingConfirmationPage extends BasePage {
   private readonly managePrisonVisitsButton: Locator
   private readonly cancelTheBookingLink: Locator
   private readonly additionalSupportDetails: Locator
+  private readonly prisonerNumber: Locator
 
   constructor(page: Page) {
     super(page)
@@ -14,6 +15,7 @@ export default class BookingConfirmationPage extends BasePage {
     this.additionalSupportDetails = page.locator('dl dt:has-text("Additional support requests") + dd')
     this.managePrisonVisitsButton = page.getByRole('button', { name: 'Go to manage prison visits' })
     this.cancelTheBookingLink = page.getByText('cancel the booking')
+    this.prisonerNumber = this.page.locator('.govuk-summary-list__value.test-visit-prisoner-number')
   }
 
   async displayBookingConfirmation(): Promise<string> {
@@ -38,4 +40,8 @@ export default class BookingConfirmationPage extends BasePage {
     return (await this.additionalSupportDetails.locator('p').allInnerTexts()).join(' ')
   }
 
+  async getPrisonerNumber(): Promise<string> {
+    const prisonerNum = this.prisonerNumber
+    return prisonerNum.innerText()
+  }
 }

--- a/src/support/testingHelperClient.ts
+++ b/src/support/testingHelperClient.ts
@@ -64,6 +64,17 @@ export const cancelVisit = async ({ request }: { request: APIRequestContext }, v
   return response.status()
 }
 
+
+export const clearVisits = async ({ request }: { request: APIRequestContext }, prisonerNumber: string) => {
+  const accessToken = globalData.get('authToken')
+  const response = await request.delete(`${testHelperUri}/test/prisoner/${prisonerNumber}/clear-visits`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+  return response.status()
+}
+
 export const updateModifyTimestamp = async (
   { request }: { request: APIRequestContext },
   applicationReference: string,


### PR DESCRIPTION
## What does this pull request do?

Added a 'clearVisits' function to the testing helper and updated the existing non-association test

## What is the intent behind these changes?

Tests were failing because changing the establishment switched the environment to 'Dev', causing the 'after all' hook to not work as intended.