### PR TITLE
VB-4903 Block dates and sessions fixes

### DIFF
--- a/playwright-e2e/pages/BlockVisitDatePage.ts
+++ b/playwright-e2e/pages/BlockVisitDatePage.ts
@@ -4,9 +4,10 @@ import { Locator, Page ,expect} from "@playwright/test"
 export default class BlockVisitDatePage extends BasePage {
 
     private readonly inputDate: Locator
+    private readonly selectFullDayRadio: Locator
     private readonly confirmYesRadio: Locator
     private readonly confirmNoRadio: Locator
-    private readonly blockedDateStatusMesssage: Locator
+    private readonly blockedDateStatusMessage: Locator
     private readonly dateBlockedError: Locator
     private readonly unblockDateLink: Locator
 
@@ -14,15 +15,20 @@ export default class BlockVisitDatePage extends BasePage {
         super(page)
 
         this.inputDate = page.locator('input[id$=date]')
+        this.selectFullDayRadio = page.getByRole('radio', { name: 'The full day' })
         this.confirmYesRadio = page.getByLabel('yes')
         this.confirmNoRadio = page.getByLabel('No')
-        this.blockedDateStatusMesssage = page.locator('.moj-alert__content')
+        this.blockedDateStatusMessage = page.locator('.moj-alert__content')
         this.dateBlockedError =page.locator('.govuk-error-summary__body')
-        this.unblockDateLink = page.locator('[data-test="unblock-date-1"]')
+        this.unblockDateLink = page.locator('[data-test="unblock-1"]')
     }
 
     async enterDateToBlock(blockDate: string): Promise<void> {
         await this.inputDate.fill(blockDate)
+    }
+
+    async selectFullDay(): Promise<void> {
+        await this.selectFullDayRadio.check()
     }
 
     async confirmBlockDate(): Promise<void> {
@@ -30,7 +36,7 @@ export default class BlockVisitDatePage extends BasePage {
     }
 
     async confirmationMessage(msg: string): Promise<void> {
-        const text = this.blockedDateStatusMesssage
+        const text = this.blockedDateStatusMessage
         expect(text).toHaveText(msg)
     }
 

--- a/playwright-e2e/setup/Constants.ts
+++ b/playwright-e2e/setup/Constants.ts
@@ -14,6 +14,7 @@ export default class Constants {
     static readonly PRISONER_TWO = "A6036DZ"
     static readonly PRISON_TWO_CODE = "DHI"
     static readonly PRISONER_THREE = "A8900DZ"
+    static readonly PRISON_THREE_CODE = "BLI"
     static readonly PRISONER_FOUR = "A8899DZ"
     static readonly PRISONER_FIVE = "A6038DZ"
     static readonly PRISONER_SIX = "A6541DZ"

--- a/playwright-e2e/support/testingHelperClient.ts
+++ b/playwright-e2e/support/testingHelperClient.ts
@@ -286,7 +286,7 @@ export const createSessionTemplate = async (
     if (!response.ok()) {
       console.error('Failed to create template', { status: response.status(), templateId })
     } else {
-      console.log('✅ Template created:', { status: response.status(), templateId })
+      console.log('✅ Template created:', { status: response.status(), payload })
     }
 
     return { status: response.status(), templateId }

--- a/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
+++ b/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
@@ -19,8 +19,8 @@ test.describe('Staff should be able to block dates for social visits', () => {
   test('Block a vist date', async ({ homePage, blockVisitDatePage }) => {
     // Navigate to the Block Visit Dates page
     await homePage.clickOnBlockVisitDates()
-    await blockVisitDatePage.checkOnPage('Block visit dates - Social visits - DPS')
-    expect(await blockVisitDatePage.headerOnPage('Block visit dates')).toBeTruthy
+    await blockVisitDatePage.checkOnPage('Block visit dates or sessions- Social visits - DPS')
+    expect(await blockVisitDatePage.headerOnPage('Block visit dates or sessions')).toBeTruthy
 
     // Block a specific date
     const blockDate = '25/11/2026'
@@ -45,8 +45,8 @@ test.describe('Staff should be able to block dates for social visits', () => {
 
     // Navigate to Block Visit Dates page
     await homePage.clickOnBlockVisitDates()
-    await blockVisitDatePage.checkOnPage('Block visit dates - Social visits - DPS')
-    expect(await blockVisitDatePage.headerOnPage('Block visit dates')).toBeTruthy
+    await blockVisitDatePage.checkOnPage('Block visit dates or sessions - Social visits - DPS')
+    expect(await blockVisitDatePage.headerOnPage('Block visit dates or sessions')).toBeTruthy
 
     // Block the date and verify error message
     await blockVisitDatePage.enterDateToBlock(blockedDate)

--- a/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
+++ b/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
@@ -1,7 +1,9 @@
+import { format } from 'date-fns'
 import { test, expect } from '../fixtures/PageFixtures'
 import GlobalData from '../setup/GlobalData'
-import { getAccessToken } from '../support/testingHelperClient'
+import { createSessionTemplate, deleteTemplate, getAccessToken } from '../support/testingHelperClient'
 import { UserType } from '../support/UserType'
+import Constants from '../setup/Constants'
 
 test.beforeAll('Get access token and store so it is available as global data', async ({ request }, testInfo) => {
   GlobalData.set('authToken', await getAccessToken({ request }))
@@ -9,6 +11,43 @@ test.beforeAll('Get access token and store so it is available as global data', a
 })
 
 test.describe('Staff should be able to block dates for social visits', () => {
+  // Set up test date for block
+  const today = new Date()
+  const firstOfNextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1)
+  const blockDate = format(firstOfNextMonth, 'dd/MM/yyyy')
+  const blockDateFormatted = format(firstOfNextMonth, 'EEEE d MMMM yyyy')
+
+  test.beforeAll(async ({ request}) => {
+    // Create a session template for the day to be blocked
+    // to ensure the full day / single session screen is shown
+    const sessionSlotTime = firstOfNextMonth
+    sessionSlotTime.setHours(9, 0, 0, 0)
+    const sessionEndTime = new Date(sessionSlotTime)
+    sessionEndTime.setHours(10, 0, 0, 0)
+
+    const { status: templateStatus, templateId } = await createSessionTemplate(
+      { request },
+      sessionSlotTime,
+      Constants.PRISON_ONE_CODE,
+      1,
+      0,
+      1,
+      null,
+      null,
+      'FEMALE_CLOSED',
+      false,
+      'Automation Tests - date block',
+      sessionEndTime,
+    )
+    expect(templateStatus).toBe(201)
+    expect(templateId).toBeTruthy()
+
+    // Track created template
+    const createdTemplates = GlobalData.get('createdTemplates') || []
+    createdTemplates.push(templateId)
+    GlobalData.set('createdTemplates', createdTemplates)
+  })
+
   test.beforeEach(async ({ loginPage, homePage }) => {
     await loginPage.navigateTo('/')
     await loginPage.checkOnPage('HMPPS Digital Services - Sign in')
@@ -16,49 +55,64 @@ test.describe('Staff should be able to block dates for social visits', () => {
     await homePage.checkOnPage('Social visits - DPS')
   })
 
-  test('Block a vist date', async ({ homePage, blockVisitDatePage }) => {
+  test('Block a visit date', async ({ homePage, blockVisitDatePage }) => {
     // Navigate to the Block Visit Dates page
     await homePage.clickOnBlockVisitDates()
-    await blockVisitDatePage.checkOnPage('Block visit dates or sessions- Social visits - DPS')
+    await blockVisitDatePage.checkOnPage('Block visit dates or sessions - Social visits - DPS')
     expect(await blockVisitDatePage.headerOnPage('Block visit dates or sessions')).toBeTruthy
 
     // Block a specific date
-    const blockDate = '25/11/2026'
     await blockVisitDatePage.enterDateToBlock(blockDate)
     await blockVisitDatePage.continueToNextPage()
     expect(
-      await blockVisitDatePage.headerOnPage(`Are you sure you want to block visits on Wednesday 25 November 2026?`),
+      await blockVisitDatePage.headerOnPage(`Are you sure you want to block visits on ${blockDateFormatted}?`),
     ).toBeTruthy
+
+    // Full day or session block? Select full day
+    expect(
+      await blockVisitDatePage.headerOnPage(`What would you like to block on ${blockDateFormatted}?`),
+    ).toBeTruthy
+    await blockVisitDatePage.selectFullDay()
+    await blockVisitDatePage.continueToNextPage()
 
     // Confirm the block
     await blockVisitDatePage.confirmBlockDate()
     await blockVisitDatePage.continueToNextPage()
-    expect(await blockVisitDatePage.confirmationMessage(`Visits are blocked for Wednesday 25 November 2026.`))
+    expect(await blockVisitDatePage.confirmationMessage(`Visits are blocked for ${blockDateFormatted}.`))
       .toBeTruthy
 
     await blockVisitDatePage.signOut()
   })
   
   test('Unblock a visit date', async ({ homePage, blockVisitDatePage }) => {
-    const blockedDate = '25/11/2026'
-    // const confirmationMessage = `Visits are unblocked for Wednesday ${blockedDate}.`
-
     // Navigate to Block Visit Dates page
     await homePage.clickOnBlockVisitDates()
     await blockVisitDatePage.checkOnPage('Block visit dates or sessions - Social visits - DPS')
     expect(await blockVisitDatePage.headerOnPage('Block visit dates or sessions')).toBeTruthy
 
     // Block the date and verify error message
-    await blockVisitDatePage.enterDateToBlock(blockedDate)
+    await blockVisitDatePage.enterDateToBlock(blockDate)
     await blockVisitDatePage.continueToNextPage()
-    expect(await blockVisitDatePage.errorMsg('The date entered is already blocked')).toBeTruthy
+    expect(await blockVisitDatePage.errorMsg('The full day is already blocked for the date entered')).toBeTruthy
 
     // Unblock the date and verify confirmation message
     await blockVisitDatePage.unBlockDate()
-    expect(await blockVisitDatePage.confirmationMessage('Visits are unblocked for Wednesday 25 November 2026.'))
+    expect(await blockVisitDatePage.confirmationMessage(`Visits are unblocked for ${blockDateFormatted}.`))
       .toBeTruthy
 
     // Sign out
     await blockVisitDatePage.signOut()
+  })
+
+  // Delete created session templates and clear global cache
+  test.afterAll('Delete created session templates and clear global cache', async ({ request }) => {
+    const createdTemplates = GlobalData.get('createdTemplates') || []
+    for (const templateId of createdTemplates) {
+      const status = await deleteTemplate({ request }, templateId)
+      console.log(`Deleted template ${templateId}, status: ${status}`)
+    }
+
+    GlobalData.clear()
+    console.log('Global data cache cleared.')
   })
 })

--- a/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
+++ b/playwright-e2e/tests/block-dates-for-social-visits.spec.ts
@@ -11,13 +11,22 @@ test.beforeAll('Get access token and store so it is available as global data', a
 })
 
 test.describe('Staff should be able to block dates for social visits', () => {
+  test.slow()
+
   // Set up test date for block
   const today = new Date()
   const firstOfNextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1)
   const blockDate = format(firstOfNextMonth, 'dd/MM/yyyy')
   const blockDateFormatted = format(firstOfNextMonth, 'EEEE d MMMM yyyy')
 
-  test.beforeAll(async ({ request}) => {
+  test.beforeEach(async ({ loginPage, homePage }) => {  
+    await loginPage.navigateTo('/')
+    await loginPage.checkOnPage('HMPPS Digital Services - Sign in')
+    await loginPage.signInWith(UserType.USER_THREE)
+    await homePage.checkOnPage('Social visits - DPS')
+  })
+
+  test('Block a visit date', async ({ request, homePage, blockVisitDatePage }) => {
     // Create a session template for the day to be blocked
     // to ensure the full day / single session screen is shown
     const sessionSlotTime = firstOfNextMonth
@@ -28,7 +37,7 @@ test.describe('Staff should be able to block dates for social visits', () => {
     const { status: templateStatus, templateId } = await createSessionTemplate(
       { request },
       sessionSlotTime,
-      Constants.PRISON_ONE_CODE,
+      Constants.PRISON_THREE_CODE,
       1,
       0,
       1,
@@ -42,20 +51,6 @@ test.describe('Staff should be able to block dates for social visits', () => {
     expect(templateStatus).toBe(201)
     expect(templateId).toBeTruthy()
 
-    // Track created template
-    const createdTemplates = GlobalData.get('createdTemplates') || []
-    createdTemplates.push(templateId)
-    GlobalData.set('createdTemplates', createdTemplates)
-  })
-
-  test.beforeEach(async ({ loginPage, homePage }) => {
-    await loginPage.navigateTo('/')
-    await loginPage.checkOnPage('HMPPS Digital Services - Sign in')
-    await loginPage.signInWith(UserType.USER_THREE)
-    await homePage.checkOnPage('Social visits - DPS')
-  })
-
-  test('Block a visit date', async ({ homePage, blockVisitDatePage }) => {
     // Navigate to the Block Visit Dates page
     await homePage.clickOnBlockVisitDates()
     await blockVisitDatePage.checkOnPage('Block visit dates or sessions - Social visits - DPS')
@@ -82,6 +77,10 @@ test.describe('Staff should be able to block dates for social visits', () => {
       .toBeTruthy
 
     await blockVisitDatePage.signOut()
+
+    // Clean up - delete the created template
+    const status = await deleteTemplate({ request }, templateId ?? '')
+    console.log(`Deleted template ${templateId}, status: ${status}`)
   })
   
   test('Unblock a visit date', async ({ homePage, blockVisitDatePage }) => {
@@ -102,17 +101,5 @@ test.describe('Staff should be able to block dates for social visits', () => {
 
     // Sign out
     await blockVisitDatePage.signOut()
-  })
-
-  // Delete created session templates and clear global cache
-  test.afterAll('Delete created session templates and clear global cache', async ({ request }) => {
-    const createdTemplates = GlobalData.get('createdTemplates') || []
-    for (const templateId of createdTemplates) {
-      const status = await deleteTemplate({ request }, templateId)
-      console.log(`Deleted template ${templateId}, status: ${status}`)
-    }
-
-    GlobalData.clear()
-    console.log('Global data cache cleared.')
   })
 })


### PR DESCRIPTION
* Changes to page content now dates **and** sessions can be blocked
* Add session template creation/deletion to the block date test to ensure a template is present so day/session block prompt flow is followed
* Remove hard-coded block test date so it will continue to work past this date